### PR TITLE
flake.nix: drop devShell, use mkShellNoCC over mkShell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,7 @@
         pkgs = nixpkgs.legacyPackages.${system};
       in {
         devShells.default = pkgs.mkShellNoCC {
-          nativeBuildInputs = with pkgs; [
+          packages = with pkgs; [
             nodePackages.prettier
             nushell
           ];


### PR DESCRIPTION
closes #17.

sneaked another thing in there, `packages` over `nativeBuildInputs`:
see https://github.com/NixOS/nixpkgs/blob/master/pkgs/build-support/mkshell/default.nix#L40.

`packages` is the preferred way of doing this.
