### PR TITLE
feat(nix): add flake-compat

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,10 @@
+(import (
+  let
+    rev = "v1.1.0";
+    sha256 = "sha256:19d2z6xsvpxm184m41qrpi1bplilwipgnzv9jy17fgw421785q1m";
+  in
+  fetchTarball {
+    inherit sha256;
+    url = "https://github.com/NixOS/flake-compat/archive/${rev}.tar.gz";
+  }
+) { src = ./.; }).shellNix


### PR DESCRIPTION
Fixes #22

I set a fixed rev and sha256 to use the v1.1.0 tag of [flake-compat](https://github.com/NixOS/flake-compat) which has been stable for a while.