### PR TITLE
autoclosed PR for denounced user uses softer messaging

### DIFF
--- a/vouch/github.nu
+++ b/vouch/github.nu
@@ -86,7 +86,7 @@ export def gh-check-pr [
 
     print "Closing PR"
 
-    let message = "This PR has been automatically closed because the author has been denounced."
+    let message = "This PR has been automatically closed because the author is explicitly blocked in the vouch list."
 
     if $dry_run {
       print "(dry-run) Would post comment and close PR"


### PR DESCRIPTION
Fixes #35

It'd be better to support full customization here but this resolves the only place the nouns get out for this.