### PR TITLE
actions/setup-vouch: put `vouch` on the PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ See the linked README in the action directory for full usage details.
 | [check-pr](action/check-pr/README.md)                         | `pull_request_target` | Check if a PR author is vouched on open or reopen. Bots and collaborators with write access are automatically allowed. Optionally auto-close PRs from unvouched or denounced users. |
 | [manage-by-discussion](action/manage-by-discussion/README.md) | `discussion_comment`  | Let collaborators vouch, denounce, or unvouch users via discussion comments. Updates the vouched file and commits the change.                                                       |
 | [manage-by-issue](action/manage-by-issue/README.md)           | `issue_comment`       | Let collaborators vouch or denounce users via issue comments. Updates the vouched file and commits the change.                                                                      |
+| [setup-vouch](action/setup-vouch/README.md)                   | Any                   | Install the `vouch` CLI on `PATH`. Nushell is installed automatically if not already available.                                                                                     |
 
 ### CLI
 

--- a/action/setup-vouch/README.md
+++ b/action/setup-vouch/README.md
@@ -1,0 +1,41 @@
+# Setup Vouch
+
+Make the `vouch` CLI available on `PATH` for subsequent workflow
+steps. Nushell is installed automatically if `nu` is not already
+available.
+
+## Usage
+
+```yaml
+jobs:
+  example:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mitchellh/vouch/action/setup-vouch@v1
+
+      - run: vouch check someuser
+```
+
+### Capturing output
+
+Use `$GITHUB_OUTPUT` to expose the result to later steps:
+
+```yaml
+- id: check
+  run: echo "status=$(vouch check someuser)" >> "$GITHUB_OUTPUT"
+
+- run: echo "${{ steps.check.outputs.status }}"
+```
+
+### Typed arguments
+
+Some commands accept typed flags (e.g. `--vouch-keyword`). Pass them
+using Nushell syntax:
+
+```yaml
+- run: |
+    vouch gh-manage-by-issue 123 456789 \
+      --repo owner/repo \
+      --vouch-keyword [lgtm approve] \
+      --dry-run=false
+```

--- a/action/setup-vouch/action.yml
+++ b/action/setup-vouch/action.yml
@@ -1,0 +1,44 @@
+name: Setup Vouch
+description: "Install Nushell and make the vouch CLI available on PATH."
+
+runs:
+  using: composite
+  steps:
+    - id: check-nu
+      shell: bash
+      run: |
+        if command -v nu &>/dev/null; then
+          echo "found=true" >> "$GITHUB_OUTPUT"
+        fi
+
+    - if: steps.check-nu.outputs.found != 'true'
+      uses: hustcer/setup-nu@920172d92eb04671776f3ba69d605d3b09351c30 # v3.22
+      with:
+        version: "*"
+
+    # Generate a bash wrapper script and a small Nu entrypoint that
+    # loads the vouch module. Place the wrapper on PATH so subsequent
+    # steps can call `vouch` directly.
+    - shell: nu {0}
+      run: |
+        let vouch_root = ("${{ github.action_path }}" | path join ".." ".." | path expand)
+        let bin_dir = ($vouch_root | path join ".vouch-bin")
+        mkdir $bin_dir
+
+        let vouch_mod = ($vouch_root | path join "vouch")
+        [
+          "#!/usr/bin/env bash"
+          "# Nu modules can't be invoked directly as scripts, so we use"
+          "# nu -c with 'use vouch *' to bring subcommands into scope."
+          "#"
+          "# Build a shell-safe argument string from the caller's args."
+          "cmd=''"
+          "for a in \"$@\"; do cmd=\"$cmd $(printf '%q' \"$a\")\"; done"
+          "# With no args, call 'vouch main' for usage info since bare"
+          "# 'vouch' doesn't resolve via 'use vouch *'."
+          $"if [ $# -eq 0 ]; then cmd='vouch main'; fi"
+          $"exec nu --no-config-file -c \"use ($vouch_mod) *; $cmd\""
+        ] | str join "\n" | save -f ($bin_dir | path join "vouch")
+        chmod +x ($bin_dir | path join "vouch")
+
+        $bin_dir | save --append $env.GITHUB_PATH


### PR DESCRIPTION
This adds a new action that installs the `vouch` CLI on the PATH. Nushell is installed automatically if not already available. A bash wrapper script delegates to the vouch Nu module, so subsequent workflow steps can call `vouch check`, `vouch add`, etc. directly.

Since this is a `bash` wrapper, you can call it from pretty much anywhere!

The README shows how output can be captured and used too.

**Warning: I vibe coded this and didn't verify it actually works.** I read the source and it LOOKS like it'd work (I know all the tech at play here), but testing GHA outside of GHA sucks huge so I still need to do that. <_<