### PR TITLE
Fix: Prevent Nushell from exiting after performing a username check

### DIFF
--- a/vouch/cli.nu
+++ b/vouch/cli.nu
@@ -81,15 +81,14 @@ export def check [
   match $status {
     "vouched" => {
       print $"($username) is vouched"
-      exit 0
     }
     "denounced" => {
       print $"($username) is denounced"
-      exit 1
+      if not $nu.is-interactive { exit 1 }
     }
     _ => {
       print $"($username) is unknown"
-      exit 2
+      if not $nu.is-interactive { exit 2 }
     }
   }
 }


### PR DESCRIPTION
This is a fix for a UX bug where the user has to relaunch Nushell after every username check.