### PR TITLE
manage-by-issue/discussion: configurable roles with legacy permission fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,8 @@ vouch gh-manage-by-issue 123 456789 --repo owner/repo
 vouch gh-manage-by-issue 123 456789 --repo owner/repo --dry-run=false
 ```
 
-Responds to comments from collaborators with write access:
+Responds to comments from collaborators with sufficient role
+(admin, maintain, write, or triage by default):
 
 - `vouch` — vouches for the issue author
 - `vouch @user` — vouches for a specific user

--- a/action/manage-by-discussion/README.md
+++ b/action/manage-by-discussion/README.md
@@ -1,10 +1,11 @@
 # Manage by Discussion
 
 Manage contributor vouch status via discussion comments. When a collaborator
-with write access comments `vouch` on a discussion, the discussion author is
-added to the vouched contributors list. When they comment `denounce`, the user
-is denounced. When they comment `unvouch`, the user is removed from the list
-entirely. The trigger keywords are configurable.
+with sufficient permissions comments `vouch` on a discussion, the discussion
+author is added to the vouched contributors list. When they comment `denounce`,
+the user is denounced. When they comment `unvouch`, the user is removed from
+the list entirely. The trigger keywords and required permission levels are
+configurable.
 
 Discussion data (comment body, commenter, discussion author) is fetched via
 the GitHub GraphQL API since discussions are not available through the REST API.
@@ -41,19 +42,20 @@ jobs:
 
 ## Inputs
 
-| Name                | Required | Default   | Description                                                            |
-| ------------------- | -------- | --------- | ---------------------------------------------------------------------- |
-| `comment-node-id`   | Yes      |           | GraphQL node ID of the discussion comment                              |
-| `discussion-number` | Yes      |           | Discussion number                                                      |
-| `allow-denounce`    | No       | `"true"`  | Enable denounce handling                                               |
-| `allow-unvouch`     | No       | `"true"`  | Enable unvouch handling                                                |
-| `allow-vouch`       | No       | `"true"`  | Enable vouch handling                                                  |
-| `denounce-keyword`  | No       | `""`      | Comma-separated keywords that trigger denouncing (default: `denounce`) |
-| `dry-run`           | No       | `"false"` | Print what would happen without making changes                         |
-| `repo`              | No       | `""`      | Repository in `owner/repo` format (default: current repository)        |
-| `unvouch-keyword`   | No       | `""`      | Comma-separated keywords that trigger unvouching (default: `unvouch`)  |
-| `vouch-keyword`     | No       | `""`      | Comma-separated keywords that trigger vouching (default: `vouch`)      |
-| `vouched-file`      | No       | `""`      | Path to vouched contributors file (empty = auto-detect)                |
+| Name                | Required | Default   | Description                                                                                                                                                        |
+| ------------------- | -------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `comment-node-id`   | Yes      |           | GraphQL node ID of the discussion comment                                                                                                                          |
+| `discussion-number` | Yes      |           | Discussion number                                                                                                                                                  |
+| `allow-denounce`    | No       | `"true"`  | Enable denounce handling                                                                                                                                           |
+| `allow-unvouch`     | No       | `"true"`  | Enable unvouch handling                                                                                                                                            |
+| `allow-vouch`       | No       | `"true"`  | Enable vouch handling                                                                                                                                              |
+| `denounce-keyword`  | No       | `""`      | Comma-separated keywords that trigger denouncing (default: `denounce`)                                                                                             |
+| `dry-run`           | No       | `"false"` | Print what would happen without making changes                                                                                                                     |
+| `roles`             | No       | `""`      | Comma-separated role names allowed to manage (default: `admin,maintain,write,triage`). When empty, also accepts the legacy `permission` values `admin` or `write`. |
+| `repo`              | No       | `""`      | Repository in `owner/repo` format (default: current repository)                                                                                                    |
+| `unvouch-keyword`   | No       | `""`      | Comma-separated keywords that trigger unvouching (default: `unvouch`)                                                                                              |
+| `vouch-keyword`     | No       | `""`      | Comma-separated keywords that trigger vouching (default: `vouch`)                                                                                                  |
+| `vouched-file`      | No       | `""`      | Path to vouched contributors file (empty = auto-detect)                                                                                                            |
 
 ## Outputs
 
@@ -63,7 +65,7 @@ jobs:
 
 ## Comment Syntax
 
-Comments from collaborators with write access are matched:
+Comments from collaborators with sufficient permissions are matched:
 
 - **`vouch`** — vouches for the discussion author (customizable via `vouch-keyword`)
 - **`vouch @user`** — vouches for a specific user

--- a/action/manage-by-discussion/action.yml
+++ b/action/manage-by-discussion/action.yml
@@ -28,6 +28,10 @@ inputs:
     description: "Print what would happen without making changes."
     required: false
     default: "false"
+  roles:
+    description: "Comma-separated list of GitHub role names allowed to manage (default: admin,maintain,write,triage)."
+    required: false
+    default: ""
   repo:
     description: "Repository in 'owner/repo' format (default: current repository)."
     required: false
@@ -65,6 +69,7 @@ runs:
         let vouch_kw = "${{ inputs.vouch-keyword }}" | split row "," | each { str trim } | where { $in | is-not-empty }
         let denounce_kw = "${{ inputs.denounce-keyword }}" | split row "," | each { str trim } | where { $in | is-not-empty }
         let unvouch_kw = "${{ inputs.unvouch-keyword }}" | split row "," | each { str trim } | where { $in | is-not-empty }
+        let roles = "${{ inputs.roles }}" | split row "," | each { str trim } | where { $in | is-not-empty }
 
         let status = (gh-manage-by-discussion
           ${{ inputs.discussion-number }}
@@ -77,6 +82,7 @@ runs:
           --allow-vouch=${{ inputs.allow-vouch }}
           --allow-denounce=${{ inputs.allow-denounce }}
           --allow-unvouch=${{ inputs.allow-unvouch }}
+          --roles $roles
           --dry-run=${{ inputs.dry-run }}
         )
         $"status=($status)" | save --append $env.GITHUB_OUTPUT

--- a/action/manage-by-issue/README.md
+++ b/action/manage-by-issue/README.md
@@ -1,10 +1,11 @@
 # Manage by Issue
 
 Manage contributor vouch status via issue comments. When a collaborator
-with write access comments `vouch` on an issue, the issue author is added
-to the vouched contributors list. When they comment `denounce`, the user
-is denounced. When they comment `unvouch`, the user is removed from the
-list entirely. The trigger keywords are configurable.
+with sufficient permissions comments `vouch` on an issue, the issue author
+is added to the vouched contributors list. When they comment `denounce`,
+the user is denounced. When they comment `unvouch`, the user is removed
+from the list entirely. The trigger keywords and required permission
+levels are configurable.
 
 ## Usage
 
@@ -40,19 +41,20 @@ jobs:
 
 ## Inputs
 
-| Name               | Required | Default   | Description                                                            |
-| ------------------ | -------- | --------- | ---------------------------------------------------------------------- |
-| `comment-id`       | Yes      |           | GitHub comment ID                                                      |
-| `issue-id`         | Yes      |           | GitHub issue number                                                    |
-| `repo`             | Yes      |           | Repository in `owner/repo` format                                      |
-| `allow-denounce`   | No       | `"true"`  | Enable denounce handling                                               |
-| `allow-unvouch`    | No       | `"true"`  | Enable unvouch handling                                                |
-| `allow-vouch`      | No       | `"true"`  | Enable vouch handling                                                  |
-| `denounce-keyword` | No       | `""`      | Comma-separated keywords that trigger denouncing (default: `denounce`) |
-| `dry-run`          | No       | `"false"` | Print what would happen without making changes                         |
-| `unvouch-keyword`  | No       | `""`      | Comma-separated keywords that trigger unvouching (default: `unvouch`)  |
-| `vouch-keyword`    | No       | `""`      | Comma-separated keywords that trigger vouching (default: `vouch`)      |
-| `vouched-file`     | No       | `""`      | Path to vouched contributors file (empty = auto-detect)                |
+| Name               | Required | Default   | Description                                                                                                                                                        |
+| ------------------ | -------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `comment-id`       | Yes      |           | GitHub comment ID                                                                                                                                                  |
+| `issue-id`         | Yes      |           | GitHub issue number                                                                                                                                                |
+| `repo`             | Yes      |           | Repository in `owner/repo` format                                                                                                                                  |
+| `allow-denounce`   | No       | `"true"`  | Enable denounce handling                                                                                                                                           |
+| `allow-unvouch`    | No       | `"true"`  | Enable unvouch handling                                                                                                                                            |
+| `allow-vouch`      | No       | `"true"`  | Enable vouch handling                                                                                                                                              |
+| `denounce-keyword` | No       | `""`      | Comma-separated keywords that trigger denouncing (default: `denounce`)                                                                                             |
+| `dry-run`          | No       | `"false"` | Print what would happen without making changes                                                                                                                     |
+| `roles`            | No       | `""`      | Comma-separated role names allowed to manage (default: `admin,maintain,write,triage`). When empty, also accepts the legacy `permission` values `admin` or `write`. |
+| `unvouch-keyword`  | No       | `""`      | Comma-separated keywords that trigger unvouching (default: `unvouch`)                                                                                              |
+| `vouch-keyword`    | No       | `""`      | Comma-separated keywords that trigger vouching (default: `vouch`)                                                                                                  |
+| `vouched-file`     | No       | `""`      | Path to vouched contributors file (empty = auto-detect)                                                                                                            |
 
 ## Outputs
 
@@ -62,7 +64,7 @@ jobs:
 
 ## Comment Syntax
 
-Comments from collaborators with write access are matched:
+Comments from collaborators with sufficient permissions are matched:
 
 - **`vouch`** — vouches for the issue author (customizable via `vouch-keyword`)
 - **`vouch @user`** — vouches for a specific user

--- a/action/manage-by-issue/action.yml
+++ b/action/manage-by-issue/action.yml
@@ -28,6 +28,10 @@ inputs:
     description: "Print what would happen without making changes."
     required: false
     default: "false"
+  roles:
+    description: "Comma-separated list of GitHub role names allowed to manage (default: admin,maintain,write,triage)."
+    required: false
+    default: ""
   repo:
     description: "Repository in 'owner/repo' format (default: current repository)."
     required: false
@@ -65,6 +69,7 @@ runs:
         let vouch_kw = "${{ inputs.vouch-keyword }}" | split row "," | each { str trim } | where { $in | is-not-empty }
         let denounce_kw = "${{ inputs.denounce-keyword }}" | split row "," | each { str trim } | where { $in | is-not-empty }
         let unvouch_kw = "${{ inputs.unvouch-keyword }}" | split row "," | each { str trim } | where { $in | is-not-empty }
+        let roles = "${{ inputs.roles }}" | split row "," | each { str trim } | where { $in | is-not-empty }
 
         let status = (gh-manage-by-issue
           ${{ inputs.issue-id }}
@@ -77,6 +82,7 @@ runs:
           --allow-vouch=${{ inputs.allow-vouch }}
           --allow-denounce=${{ inputs.allow-denounce }}
           --allow-unvouch=${{ inputs.allow-unvouch }}
+          --roles $roles
           --dry-run=${{ inputs.dry-run }}
         )
         $"status=($status)" | save --append $env.GITHUB_OUTPUT


### PR DESCRIPTION
Add a --roles flag to gh-manage-by-issue and gh-manage-by-discussion that controls which GitHub role_name values are allowed to manage the vouched list. The default is admin, maintain, write, and triage.

The key difference here is the addition of accepting **triage**, since the prior approach of using the legacy permission only accepted `admin` and `write`, but `triage` maps to `read` in the legacy model.

When --roles is empty (the default), the permission check also accepts the legacy permission field values "admin" or "write" from the collaborator API. This handles cases where the newer role_name field may not reflect the expected value but the legacy permission does. When --roles is explicitly provided, only role_name is checked.