### PR TITLE
github: add manage permission to be specified by another vouch file

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,8 @@ Responds to comments from collaborators with sufficient role
 - `denounce @user <reason>` — denounces a specific user with a reason
 
 Keywords are customizable via `--vouch-keyword` and `--denounce-keyword`.
+You can also allow specific managers listed in a separate VOUCHED file
+via `--vouched-managers`.
 
 Outputs status: `vouched`, `denounced`, or `unchanged`.
 

--- a/action/manage-by-discussion/README.md
+++ b/action/manage-by-discussion/README.md
@@ -42,20 +42,23 @@ jobs:
 
 ## Inputs
 
-| Name                | Required | Default   | Description                                                                                                                                                        |
-| ------------------- | -------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `comment-node-id`   | Yes      |           | GraphQL node ID of the discussion comment                                                                                                                          |
-| `discussion-number` | Yes      |           | Discussion number                                                                                                                                                  |
-| `allow-denounce`    | No       | `"true"`  | Enable denounce handling                                                                                                                                           |
-| `allow-unvouch`     | No       | `"true"`  | Enable unvouch handling                                                                                                                                            |
-| `allow-vouch`       | No       | `"true"`  | Enable vouch handling                                                                                                                                              |
-| `denounce-keyword`  | No       | `""`      | Comma-separated keywords that trigger denouncing (default: `denounce`)                                                                                             |
-| `dry-run`           | No       | `"false"` | Print what would happen without making changes                                                                                                                     |
-| `roles`             | No       | `""`      | Comma-separated role names allowed to manage (default: `admin,maintain,write,triage`). When empty, also accepts the legacy `permission` values `admin` or `write`. |
-| `repo`              | No       | `""`      | Repository in `owner/repo` format (default: current repository)                                                                                                    |
-| `unvouch-keyword`   | No       | `""`      | Comma-separated keywords that trigger unvouching (default: `unvouch`)                                                                                              |
-| `vouch-keyword`     | No       | `""`      | Comma-separated keywords that trigger vouching (default: `vouch`)                                                                                                  |
-| `vouched-file`      | No       | `""`      | Path to vouched contributors file (empty = auto-detect)                                                                                                            |
+| Name                    | Required | Default   | Description                                                                                                                                                        |
+| ----------------------- | -------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `comment-node-id`       | Yes      |           | GraphQL node ID of the discussion comment                                                                                                                          |
+| `discussion-number`     | Yes      |           | Discussion number                                                                                                                                                  |
+| `allow-denounce`        | No       | `"true"`  | Enable denounce handling                                                                                                                                           |
+| `allow-unvouch`         | No       | `"true"`  | Enable unvouch handling                                                                                                                                            |
+| `allow-vouch`           | No       | `"true"`  | Enable vouch handling                                                                                                                                              |
+| `denounce-keyword`      | No       | `""`      | Comma-separated keywords that trigger denouncing (default: `denounce`)                                                                                             |
+| `dry-run`               | No       | `"false"` | Print what would happen without making changes                                                                                                                     |
+| `roles`                 | No       | `""`      | Comma-separated role names allowed to manage (default: `admin,maintain,write,triage`). When empty, also accepts the legacy `permission` values `admin` or `write`. |
+| `repo`                  | No       | `""`      | Repository in `owner/repo` format (default: current repository)                                                                                                    |
+| `unvouch-keyword`       | No       | `""`      | Comma-separated keywords that trigger unvouching (default: `unvouch`)                                                                                              |
+| `vouch-keyword`         | No       | `""`      | Comma-separated keywords that trigger vouching (default: `vouch`)                                                                                                  |
+| `vouched-file`          | No       | `""`      | Path to vouched contributors file (empty = auto-detect)                                                                                                            |
+| `vouched-managers-file` | No       | `""`      | Path to managers VOUCHED file (empty = disable managers check)                                                                                                     |
+| `vouched-managers-ref`  | No       | `""`      | Git ref for the managers file (empty = default branch)                                                                                                             |
+| `vouched-managers-repo` | No       | `""`      | Repository in `owner/repo` format for managers file (empty = target repo)                                                                                          |
 
 ## Outputs
 

--- a/action/manage-by-discussion/action.yml
+++ b/action/manage-by-discussion/action.yml
@@ -28,12 +28,12 @@ inputs:
     description: "Print what would happen without making changes."
     required: false
     default: "false"
-  roles:
-    description: "Comma-separated list of GitHub role names allowed to manage (default: admin,maintain,write,triage)."
-    required: false
-    default: ""
   repo:
     description: "Repository in 'owner/repo' format (default: current repository)."
+    required: false
+    default: ""
+  roles:
+    description: "Comma-separated list of GitHub role names allowed to manage (default: admin,maintain,write,triage)."
     required: false
     default: ""
   unvouch-keyword:
@@ -46,6 +46,18 @@ inputs:
     default: ""
   vouched-file:
     description: "Path to the vouched contributors file (empty = auto-detect)."
+    required: false
+    default: ""
+  vouched-managers-file:
+    description: "Path to managers VOUCHED file (empty = disable managers check)."
+    required: false
+    default: ""
+  vouched-managers-ref:
+    description: "Git ref for the managers file (default: repository default branch)."
+    required: false
+    default: ""
+  vouched-managers-repo:
+    description: "Repository in 'owner/repo' format for managers file (default: target repo)."
     required: false
     default: ""
 
@@ -70,6 +82,15 @@ runs:
         let denounce_kw = "${{ inputs.denounce-keyword }}" | split row "," | each { str trim } | where { $in | is-not-empty }
         let unvouch_kw = "${{ inputs.unvouch-keyword }}" | split row "," | each { str trim } | where { $in | is-not-empty }
         let roles = "${{ inputs.roles }}" | split row "," | each { str trim } | where { $in | is-not-empty }
+        let vouched_managers = if ("${{ inputs.vouched-managers-file }}" | is-not-empty) {
+          {
+            repo: "${{ inputs.vouched-managers-repo }}"
+            file: "${{ inputs.vouched-managers-file }}"
+            ref: "${{ inputs.vouched-managers-ref }}"
+          }
+        } else {
+          null
+        }
 
         let status = (gh-manage-by-discussion
           ${{ inputs.discussion-number }}
@@ -83,6 +104,7 @@ runs:
           --allow-denounce=${{ inputs.allow-denounce }}
           --allow-unvouch=${{ inputs.allow-unvouch }}
           --roles $roles
+          --vouched-managers $vouched_managers
           --dry-run=${{ inputs.dry-run }}
         )
         $"status=($status)" | save --append $env.GITHUB_OUTPUT

--- a/action/manage-by-issue/README.md
+++ b/action/manage-by-issue/README.md
@@ -41,20 +41,23 @@ jobs:
 
 ## Inputs
 
-| Name               | Required | Default   | Description                                                                                                                                                        |
-| ------------------ | -------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `comment-id`       | Yes      |           | GitHub comment ID                                                                                                                                                  |
-| `issue-id`         | Yes      |           | GitHub issue number                                                                                                                                                |
-| `repo`             | Yes      |           | Repository in `owner/repo` format                                                                                                                                  |
-| `allow-denounce`   | No       | `"true"`  | Enable denounce handling                                                                                                                                           |
-| `allow-unvouch`    | No       | `"true"`  | Enable unvouch handling                                                                                                                                            |
-| `allow-vouch`      | No       | `"true"`  | Enable vouch handling                                                                                                                                              |
-| `denounce-keyword` | No       | `""`      | Comma-separated keywords that trigger denouncing (default: `denounce`)                                                                                             |
-| `dry-run`          | No       | `"false"` | Print what would happen without making changes                                                                                                                     |
-| `roles`            | No       | `""`      | Comma-separated role names allowed to manage (default: `admin,maintain,write,triage`). When empty, also accepts the legacy `permission` values `admin` or `write`. |
-| `unvouch-keyword`  | No       | `""`      | Comma-separated keywords that trigger unvouching (default: `unvouch`)                                                                                              |
-| `vouch-keyword`    | No       | `""`      | Comma-separated keywords that trigger vouching (default: `vouch`)                                                                                                  |
-| `vouched-file`     | No       | `""`      | Path to vouched contributors file (empty = auto-detect)                                                                                                            |
+| Name                    | Required | Default   | Description                                                                                                                                                        |
+| ----------------------- | -------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `comment-id`            | Yes      |           | GitHub comment ID                                                                                                                                                  |
+| `issue-id`              | Yes      |           | GitHub issue number                                                                                                                                                |
+| `repo`                  | Yes      |           | Repository in `owner/repo` format                                                                                                                                  |
+| `allow-denounce`        | No       | `"true"`  | Enable denounce handling                                                                                                                                           |
+| `allow-unvouch`         | No       | `"true"`  | Enable unvouch handling                                                                                                                                            |
+| `allow-vouch`           | No       | `"true"`  | Enable vouch handling                                                                                                                                              |
+| `denounce-keyword`      | No       | `""`      | Comma-separated keywords that trigger denouncing (default: `denounce`)                                                                                             |
+| `dry-run`               | No       | `"false"` | Print what would happen without making changes                                                                                                                     |
+| `roles`                 | No       | `""`      | Comma-separated role names allowed to manage (default: `admin,maintain,write,triage`). When empty, also accepts the legacy `permission` values `admin` or `write`. |
+| `unvouch-keyword`       | No       | `""`      | Comma-separated keywords that trigger unvouching (default: `unvouch`)                                                                                              |
+| `vouch-keyword`         | No       | `""`      | Comma-separated keywords that trigger vouching (default: `vouch`)                                                                                                  |
+| `vouched-file`          | No       | `""`      | Path to vouched contributors file (empty = auto-detect)                                                                                                            |
+| `vouched-managers-file` | No       | `""`      | Path to managers VOUCHED file (empty = disable managers check)                                                                                                     |
+| `vouched-managers-ref`  | No       | `""`      | Git ref for the managers file (empty = default branch)                                                                                                             |
+| `vouched-managers-repo` | No       | `""`      | Repository in `owner/repo` format for managers file (empty = target repo)                                                                                          |
 
 ## Outputs
 

--- a/action/manage-by-issue/action.yml
+++ b/action/manage-by-issue/action.yml
@@ -28,12 +28,12 @@ inputs:
     description: "Print what would happen without making changes."
     required: false
     default: "false"
-  roles:
-    description: "Comma-separated list of GitHub role names allowed to manage (default: admin,maintain,write,triage)."
-    required: false
-    default: ""
   repo:
     description: "Repository in 'owner/repo' format (default: current repository)."
+    required: false
+    default: ""
+  roles:
+    description: "Comma-separated list of GitHub role names allowed to manage (default: admin,maintain,write,triage)."
     required: false
     default: ""
   unvouch-keyword:
@@ -46,6 +46,18 @@ inputs:
     default: ""
   vouched-file:
     description: "Path to the vouched contributors file (empty = auto-detect)."
+    required: false
+    default: ""
+  vouched-managers-file:
+    description: "Path to managers VOUCHED file (empty = disable managers check)."
+    required: false
+    default: ""
+  vouched-managers-ref:
+    description: "Git ref for the managers file (default: repository default branch)."
+    required: false
+    default: ""
+  vouched-managers-repo:
+    description: "Repository in 'owner/repo' format for managers file (default: target repo)."
     required: false
     default: ""
 
@@ -70,6 +82,15 @@ runs:
         let denounce_kw = "${{ inputs.denounce-keyword }}" | split row "," | each { str trim } | where { $in | is-not-empty }
         let unvouch_kw = "${{ inputs.unvouch-keyword }}" | split row "," | each { str trim } | where { $in | is-not-empty }
         let roles = "${{ inputs.roles }}" | split row "," | each { str trim } | where { $in | is-not-empty }
+        let vouched_managers = if ("${{ inputs.vouched-managers-file }}" | is-not-empty) {
+          {
+            repo: "${{ inputs.vouched-managers-repo }}"
+            file: "${{ inputs.vouched-managers-file }}"
+            ref: "${{ inputs.vouched-managers-ref }}"
+          }
+        } else {
+          null
+        }
 
         let status = (gh-manage-by-issue
           ${{ inputs.issue-id }}
@@ -83,6 +104,7 @@ runs:
           --allow-denounce=${{ inputs.allow-denounce }}
           --allow-unvouch=${{ inputs.allow-unvouch }}
           --roles $roles
+          --vouched-managers $vouched_managers
           --dry-run=${{ inputs.dry-run }}
         )
         $"status=($status)" | save --append $env.GITHUB_OUTPUT


### PR DESCRIPTION
The `manage-by-discussion` and `manage-by-issue` actions now support a `vouched-managers-file` (and related) parameter, which specifies a  VOUCHED file that specially designates users who can vouch others users into the target `vouched-file` (not the managers file). 

This allows specifically designating a set of users who can vouch others rather than relying only on GitHub repo/org permissions.