### PR TITLE
manage-by-issue/discussion: add --pull-request option

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,8 @@ A file for [guiding coding agents](https://agents.md/).
 ## Nu
 
 - Try to limit line length to ~70 characters if an expression
-  can be split in a readable way across multiple lines.
+  can be split in a readable way across multiple lines. Don't split
+  strings in non-ergonomic ways just to fit within the line length limit.
 - The order of definitions in Nu files should be:
   (1) Exported definitions (alphabetically sorted)
   (2) Helper commands (exported, alphabetically sorted)

--- a/action/manage-by-discussion/README.md
+++ b/action/manage-by-discussion/README.md
@@ -51,6 +51,8 @@ jobs:
 | `allow-vouch`           | No       | `"true"`  | Enable vouch handling                                                                                                                                              |
 | `denounce-keyword`      | No       | `""`      | Comma-separated keywords that trigger denouncing (default: `denounce`)                                                                                             |
 | `dry-run`               | No       | `"false"` | Print what would happen without making changes                                                                                                                     |
+| `merge-immediately`     | No       | `"false"` | Merge the pull request immediately after creation (only applies when `pull-request` is `"true"`)                                                                   |
+| `pull-request`          | No       | `"false"` | Create a pull request instead of pushing directly                                                                                                                  |
 | `roles`                 | No       | `""`      | Comma-separated role names allowed to manage (default: `admin,maintain,write,triage`). When empty, also accepts the legacy `permission` values `admin` or `write`. |
 | `repo`                  | No       | `""`      | Repository in `owner/repo` format (default: current repository)                                                                                                    |
 | `unvouch-keyword`       | No       | `""`      | Comma-separated keywords that trigger unvouching (default: `unvouch`)                                                                                              |
@@ -86,3 +88,7 @@ Comments from collaborators with sufficient permissions are matched:
 When `dry-run` is `"false"`, the action commits and pushes any changes
 to the VOUCHED file automatically. The caller must check out the
 repository before using this action.
+
+When `pull-request` is `"true"`, the action creates a new branch and
+opens a pull request instead of pushing directly to the default branch.
+This requires `pull-requests: write` permission.

--- a/action/manage-by-discussion/action.yml
+++ b/action/manage-by-discussion/action.yml
@@ -28,6 +28,14 @@ inputs:
     description: "Print what would happen without making changes."
     required: false
     default: "false"
+  merge-immediately:
+    description: "Merge the pull request immediately after creation (only applies when pull-request is true)."
+    required: false
+    default: "false"
+  pull-request:
+    description: "Create a pull request instead of pushing directly."
+    required: false
+    default: "false"
   repo:
     description: "Repository in 'owner/repo' format (default: current repository)."
     required: false
@@ -109,6 +117,8 @@ runs:
           --roles $roles
           --vouched-managers $vouched_managers
           --commit-message $commit_msg
+          --pull-request=${{ inputs.pull-request }}
+          --merge-immediately=${{ inputs.merge-immediately }}
           --dry-run=${{ inputs.dry-run }}
         )
         $"status=($status)" | save --append $env.GITHUB_OUTPUT

--- a/action/manage-by-issue/README.md
+++ b/action/manage-by-issue/README.md
@@ -51,6 +51,8 @@ jobs:
 | `allow-vouch`           | No       | `"true"`  | Enable vouch handling                                                                                                                                              |
 | `denounce-keyword`      | No       | `""`      | Comma-separated keywords that trigger denouncing (default: `denounce`)                                                                                             |
 | `dry-run`               | No       | `"false"` | Print what would happen without making changes                                                                                                                     |
+| `merge-immediately`     | No       | `"false"` | Merge the pull request immediately after creation (only applies when `pull-request` is `"true"`)                                                                   |
+| `pull-request`          | No       | `"false"` | Create a pull request instead of pushing directly                                                                                                                  |
 | `roles`                 | No       | `""`      | Comma-separated role names allowed to manage (default: `admin,maintain,write,triage`). When empty, also accepts the legacy `permission` values `admin` or `write`. |
 | `unvouch-keyword`       | No       | `""`      | Comma-separated keywords that trigger unvouching (default: `unvouch`)                                                                                              |
 | `vouch-keyword`         | No       | `""`      | Comma-separated keywords that trigger vouching (default: `vouch`)                                                                                                  |
@@ -85,3 +87,7 @@ Comments from collaborators with sufficient permissions are matched:
 When `dry-run` is `"false"`, the action commits and pushes any changes
 to the VOUCHED file automatically. The caller must check out the
 repository before using this action.
+
+When `pull-request` is `"true"`, the action creates a new branch and
+opens a pull request instead of pushing directly to the default branch.
+This requires `pull-requests: write` permission.

--- a/action/manage-by-issue/action.yml
+++ b/action/manage-by-issue/action.yml
@@ -28,6 +28,14 @@ inputs:
     description: "Print what would happen without making changes."
     required: false
     default: "false"
+  merge-immediately:
+    description: "Merge the pull request immediately after creation (only applies when pull-request is true)."
+    required: false
+    default: "false"
+  pull-request:
+    description: "Create a pull request instead of pushing directly."
+    required: false
+    default: "false"
   repo:
     description: "Repository in 'owner/repo' format (default: current repository)."
     required: false
@@ -109,6 +117,8 @@ runs:
           --roles $roles
           --vouched-managers $vouched_managers
           --commit-message $commit_msg
+          --pull-request=${{ inputs.pull-request }}
+          --merge-immediately=${{ inputs.merge-immediately }}
           --dry-run=${{ inputs.dry-run }}
         )
         $"status=($status)" | save --append $env.GITHUB_OUTPUT

--- a/vouch/git.nu
+++ b/vouch/git.nu
@@ -5,18 +5,34 @@
 # Configures git authorship as github-actions[bot], stages the file,
 # and pushes. If there are no changes to commit, this is a no-op.
 #
+# When `--branch` is set, a new branch is created from HEAD
+# before committing. The generated branch name is returned so
+# the caller can open a pull request.
+#
 # When `--retry` is set, push failures are retried after a
 # rebase. If `--retry-action` is also provided, the closure is
 # invoked after each rebase to re-apply file changes.
 export def commit-and-push [
   file: string,              # Path to the vouched file
   --message: string = "",    # Commit message (default: "Update VOUCHED list")
+  --branch: string = "",     # Create a new branch with this prefix (e.g. "vouch/")
   --retry: int = 0,          # Max retry attempts on push failure (0 = no retry)
   --retry-action: closure,   # Closure to re-apply changes after rebase
 ] {
+  # Create the branch once so retries push the same name.
+  let branch_name = if ($branch | is-not-empty) {
+    let name = $branch + (random uuid | str substring 0..8)
+    git checkout -b $name
+
+    # Set it up so that `git push` just works.
+    git config $"branch.($name).remote" origin
+    git config $"branch.($name).merge" $"refs/heads/($name)"
+    $name
+  } 
+
   if $retry < 1 {
     push $file --message $message
-    return
+    return $branch_name
   }
 
   mut last_err = null
@@ -27,7 +43,7 @@ export def commit-and-push [
     } catch { |e| $e }
 
     if $push_err == null {
-      return
+      return $branch_name
     }
 
     $last_err = $push_err
@@ -54,9 +70,9 @@ def push [
   file: string,
   --message: string = "",
 ] {
-  # New files aren't tracked yet, so `git diff` won't see them.
-  # Stage first so the diff check below covers both new and
-  # modified files.
+  # New files aren't tracked yet, so `git diff` won't
+  # see them. Stage first so the diff check below covers
+  # both new and modified files.
   let is_new = (
     git ls-files $file | str trim | is-empty
   )
@@ -64,21 +80,22 @@ def push [
     git add $file
   }
 
-  # Exit early when the file hasn't actually changed to avoid
-  # creating empty commits.
+  # Exit early when the file hasn't actually changed to
+  # avoid creating empty commits.
   let diff = git diff --quiet $file | complete
   if $diff.exit_code == 0 and not $is_new {
     return
   }
 
-  # Configure authorship for the commit. We use the GitHub Actions
-  # bot identity so the commit is attributed to the automation
-  # rather than a human.
+  # Configure authorship for the commit. We use the GitHub
+  # Actions bot identity so the commit is attributed to the
+  # automation rather than a human.
   git config user.name "github-actions[bot]"
-  git config user.email (
-    "41898282+github-actions[bot]@users.noreply.github.com"
-  )
+  git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
   git add $file
-  git commit -m ($message | default -e "Update VOUCHED list")
+  git commit -m (
+    $message | default -e "Update VOUCHED list"
+  )
+
   git push
 }


### PR DESCRIPTION
Fixes #54

Add a --pull-request flag to gh-manage-by-issue and gh-manage-by-discussion that creates a branch and opens a pull request instead of pushing directly to the default branch. The commit-and-push helper in git.nu gains a --branch flag that creates and tracks a new branch before committing.