### PR TITLE
docs: Add installation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,26 @@ See the linked README in the action directory for full usage details.
 The CLI is implemented as a Nushell module and only requires
 Nushell to run. There are no other external dependencies.
 
+#### Installation
+
+*Using `nu`:*
+
+You can use the CLI via `nu` directly as long as `vouch` is on your library path:
+
+```nu
+use vouch *
+```
+
+*Using `pixi`:*
+
+`vouch` is available on [conda-forge](https://prefix.dev/conda-forge/vouch).
+
+```bash
+pixi global install vouch
+# run vouch without installing it
+pixi exec vouch
+```
+
 #### Integrated Help
 
 This is Nushell, so you can get help on any command:


### PR DESCRIPTION
xref #26

i basically copied your approach from https://github.com/mitchellh/vouch/pull/40 and created a small shell wrapper for the vouch cli (see https://github.com/conda-forge/vouch-feedstock-feedstock/blob/1df013988f6f0c45c29e111d42dfaf6d212199b0/recipe/vouch).

not super happy with that and would have preferred a nushell-only version over this (the `#!/usr/bin/env bash` approach feels hacky and makes shipping for windows much more annoying) but i can't think of anything immediate to solve this. i also created a discussion for this topic in the nushell discord: https://discord.com/channels/601130461678272522/1472598200278847608/1472598200278847608

[pixi](https://pixi.sh) is a modern language-agnostic cross-platform package manager that builds on the [conda-forge](https://conda-forge.org) ecosystem; somewhat similar to nix