### PR TITLE
action/sync-codeowners

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ See the linked README in the action directory for full usage details.
 | [check-user](action/check-user/README.md)                     | Any                   | Check if a GitHub user is vouched. Outputs the user's status and fails the step by default if the user is not vouched. Set `allow-fail` to only report via output.                         |
 | [manage-by-discussion](action/manage-by-discussion/README.md) | `discussion_comment`  | Let collaborators vouch, denounce, or unvouch users via discussion comments. Updates the vouched file and commits the change.                                                              |
 | [manage-by-issue](action/manage-by-issue/README.md)           | `issue_comment`       | Let collaborators vouch or denounce users via issue comments. Updates the vouched file and commits the change.                                                                             |
+| [sync-codeowners](action/sync-codeowners/README.md)           | Any                   | Sync CODEOWNERS owners into the vouch list by vouching missing users.                                                                                                                      |
 | [setup-vouch](action/setup-vouch/README.md)                   | Any                   | Install the `vouch` CLI on `PATH`. Nushell is installed automatically if not already available.                                                                                            |
 
 ### CLI

--- a/action/sync-codeowners/README.md
+++ b/action/sync-codeowners/README.md
@@ -1,0 +1,52 @@
+# Sync Codeowners
+
+Sync CODEOWNERS entries into the VOUCHED list. The action expands any
+team owners to their members and adds missing users to the vouch file.
+
+## Usage
+
+```yaml
+on:
+  schedule:
+    - cron: "0 0 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: mitchellh/vouch/action/sync-codeowners@v1
+        with:
+          repo: ${{ github.repository }}
+```
+
+## Inputs
+
+| Name                | Required | Default   | Description                                                    |
+| ------------------- | -------- | --------- | -------------------------------------------------------------- |
+| `repo`              | No       | `""`      | Repository in `owner/repo` format (empty = current repository) |
+| `codeowners-file`   | No       | `""`      | Path to CODEOWNERS file (empty = auto-detect)                  |
+| `commit-message`    | No       | `""`      | Commit message override                                        |
+| `merge-immediately` | No       | `"false"` | Merge the pull request immediately after creation              |
+| `pull-request`      | No       | `"false"` | Create a pull request instead of pushing directly              |
+| `vouched-file`      | No       | `""`      | Path to VOUCHED file (empty = auto-detect)                     |
+
+## Outputs
+
+| Name     | Description                      |
+| -------- | -------------------------------- |
+| `status` | Result: `updated` or `unchanged` |
+
+## Notes
+
+When `pull-request` is `"true"`, the action creates a branch and opens a
+pull request instead of pushing directly. This requires `pull-requests:
+write` permission and a token that can create pull requests. The default
+`GITHUB_TOKEN` **cannot** create pull requests unless you enable it in
+the repository settings.

--- a/action/sync-codeowners/action.yml
+++ b/action/sync-codeowners/action.yml
@@ -1,0 +1,55 @@
+name: Sync Codeowners
+description: "Sync CODEOWNERS entries into the VOUCHED list."
+
+inputs:
+  repo:
+    description: "Repository in 'owner/repo' format (default: current)."
+    required: false
+    default: ""
+  codeowners-file:
+    description: "Path to CODEOWNERS file (empty = auto-detect)."
+    required: false
+    default: ""
+  vouched-file:
+    description: "Path to the VOUCHED file (empty = auto-detect)."
+    required: false
+    default: ""
+  commit-message:
+    description: "Commit message override."
+    required: false
+    default: ""
+  merge-immediately:
+    description: "Merge the pull request immediately after creation."
+    required: false
+    default: "false"
+  pull-request:
+    description: "Create a pull request instead of pushing directly."
+    required: false
+    default: "false"
+
+outputs:
+  status:
+    description: "Result status: updated or unchanged"
+    value: ${{ steps.run.outputs.status }}
+
+runs:
+  using: composite
+  steps:
+    - uses: hustcer/setup-nu@920172d92eb04671776f3ba69d605d3b09351c30 # v3.22
+      with:
+        version: "*"
+
+    - id: run
+      shell: nu {0}
+      run: |
+        use "${{ github.action_path }}/../../vouch" *
+
+        let status = (gh-sync-codeowners
+          --repo "${{ inputs.repo || github.repository }}"
+          --codeowners-file "${{ inputs.codeowners-file }}"
+          --vouched-file "${{ inputs.vouched-file }}"
+          --commit-message "${{ inputs.commit-message }}"
+          --pull-request=${{ inputs.pull-request }}
+          --merge-immediately=${{ inputs.merge-immediately }}
+        )
+        $"status=($status)" | save --append $env.GITHUB_OUTPUT

--- a/tests/codeowners.nu
+++ b/tests/codeowners.nu
@@ -1,0 +1,37 @@
+use std/assert
+
+use ../vouch/codeowners.nu [parse-codeowners]
+
+def sample-codeowners-file [] {
+  let dir = (mktemp -d)
+  let path = ([$dir "CODEOWNERS"] | path join)
+  "# Sample CODEOWNERS
+/docs/ @acme/docs
+/src/ @acme/core @bob
+/src/special.txt @acme/ops @bob"
+    | save -f $path
+  $path
+}
+
+export def "test codeowners-parse returns owner files table" [] {
+  let file = sample-codeowners-file
+  let rules = open -r $file | parse-codeowners
+  assert equal $rules [
+    {
+      owner: "acme/docs"
+      files: ["/docs/"]
+    }
+    {
+      owner: "acme/core"
+      files: ["/src/"]
+    }
+    {
+      owner: "bob"
+      files: ["/src/", "/src/special.txt"]
+    }
+    {
+      owner: "acme/ops"
+      files: ["/src/special.txt"]
+    }
+  ]
+}

--- a/tests/lib.nu
+++ b/tests/lib.nu
@@ -1,7 +1,13 @@
 use std/assert
 
 use ../vouch/file.nu ["from td", "to td"]
-use ../vouch/lib.nu [add-user, check-user, denounce-user, parse-comment, remove-user]
+use ../vouch/lib.nu [
+  add-user
+  check-user
+  denounce-user
+  parse-comment
+  remove-user
+]
 
 def sample-records [] {
   "# Comment
@@ -268,3 +274,4 @@ export def "test parse-comment multiline body parses first line only" [] {
   assert equal $result.user "ditherdude"
   assert equal $result.reason ""
 }
+

--- a/vouch/cli.nu
+++ b/vouch/cli.nu
@@ -156,6 +156,7 @@ export def main [] {
   print ""
   print "GitHub integration:"
   print "  gh-check-pr         Check if a PR author is a vouched contributor"
+  print "  gh-sync-codeowners  Sync CODEOWNERS entries into the VOUCHED list"
   print "  gh-manage-by-discussion Manage contributor status via discussion comment"
   print "  gh-manage-by-issue  Manage contributor status via issue comment"
 }

--- a/vouch/codeowners.nu
+++ b/vouch/codeowners.nu
@@ -1,0 +1,46 @@
+# CODEOWNERS parsing utilities.
+
+# Parse CODEOWNERS content into a table of owner -> files.
+#
+# Each row maps an owner (user or team handle) to the list
+# of file patterns they own. Owners are sorted alphabetically.
+#
+# Owners have the leading "@" stripped.
+#
+# Example:
+#   open -r CODEOWNERS | parse-codeowners
+#   ╭───┬────────────┬──────────────────╮
+#   │ # │   owner    │      files       │
+#   ├───┼────────────┼──────────────────┤
+#   │ 0 │ acme/core  │ [/src/]          │
+#   │ 1 │ bob        │ [/src/, /docs/]  │
+#   ╰───┴────────────┴──────────────────╯
+export def parse-codeowners []: string -> table<owner: string, files: list<string>> {
+  $in
+    | lines
+    | where {|line|
+      not ($line | str starts-with "#")
+    }
+    | where {|line| ($line | str trim) != ""}
+    | where {|line| $line | str contains "@"}
+    | each {|line|
+      let parts = (
+        $line
+          | split row "#"
+          | first
+          | str trim
+          | split row " "
+          | where {|p| $p != ""}
+      )
+      let pattern = ($parts | first)
+      let owners = ($parts | skip 1)
+      $owners | each {|o| { owner: $o, pattern: $pattern }}
+    }
+    | flatten
+    | group-by owner
+    | transpose owner files
+    | update files {|r| $r.files | get pattern}
+    | update owner {|r|
+      $r.owner | str trim --left -c "@"
+    }
+}

--- a/vouch/mod.nu
+++ b/vouch/mod.nu
@@ -17,6 +17,7 @@ export use github.nu [
   gh-check-user
   gh-manage-by-discussion
   gh-manage-by-issue
+  gh-sync-codeowners
 ]
 
 # This exposes the function so `open <file>.td` works.
@@ -29,4 +30,3 @@ export use file.nu [
 
 # The API if people want to use this as a Nu library.
 export module lib.nu
-


### PR DESCRIPTION
This adds a new action that reads all the members in a repo's CODEOWNERS file and automatically vouches for them. See the README for more details.