### PR TITLE
github: add PR and issue message templating

### DIFF
--- a/action/check-issue/action.yml
+++ b/action/check-issue/action.yml
@@ -29,6 +29,10 @@ inputs:
     description: "Repository for the vouched file in 'owner/repo' format (default: same as repo)."
     required: false
     default: ""
+  template-file:
+    description: "An optional path to a response template to use for unvouched users."
+    required: false
+    default: ""
 
 outputs:
   status:
@@ -52,6 +56,7 @@ runs:
           --repo "${{ inputs.repo || github.repository }}"
           --vouched-repo "${{ inputs.vouched-repo }}"
           --vouched-file "${{ inputs.vouched-file }}"
+          --template-file "${{ inputs.template-file }}"
           --require-vouch=${{ inputs.require-vouch }}
           --auto-close=${{ inputs.auto-close }}
           --dry-run=${{ inputs.dry-run }}

--- a/action/check-pr/action.yml
+++ b/action/check-pr/action.yml
@@ -29,6 +29,10 @@ inputs:
     description: "Repository for the vouched file in 'owner/repo' format (default: same as repo)."
     required: false
     default: ""
+  template-file:
+    description: "An optional path to a response template to use for unvouched users."
+    required: false
+    default: ""
 
 outputs:
   status:
@@ -52,6 +56,7 @@ runs:
           --repo "${{ inputs.repo || github.repository }}"
           --vouched-repo "${{ inputs.vouched-repo }}"
           --vouched-file "${{ inputs.vouched-file }}"
+          --template-file "${{ inputs.template-file }}"
           --require-vouch=${{ inputs.require-vouch }}
           --auto-close=${{ inputs.auto-close }}
           --dry-run=${{ inputs.dry-run }}

--- a/tests/template.nu
+++ b/tests/template.nu
@@ -1,0 +1,53 @@
+use std/assert
+
+use ../vouch/template.nu
+
+export def "test default github unvouched PR template" [] {
+  let want = 'Hi @unvouched, thanks for your interest in contributing!
+
+This project requires that pull request authors are vouched, and you are not in the list of vouched users. 
+
+This PR will be closed automatically. See https://github.com/mitchellh/vouch/blob/main/CONTRIBUTING.md for more details.
+'
+
+  let pr_author = "unvouched"
+  let repo_parts = {
+    owner: "mitchellh",
+    name: "vouch",
+  }
+  let default_branch = "main";
+
+  const template_file = path self ../vouch/templates/github-pr-unvouched
+  let got = {
+    author: $pr_author,
+    owner: $repo_parts.owner,
+    repo: $repo_parts.name,
+    default_branch: $default_branch,
+  } | template render $template_file
+
+  assert equal $want $got
+}
+
+export def "test default github unvouched issue template" [] {
+  let want = 'Hi @unvouched, thanks for your interest!
+
+This project requires that issue reporters are vouched, and you are not in the list of vouched users. 
+
+This issue will be closed automatically. See https://github.com/mitchellh/vouch/blob/main/CONTRIBUTING.md for more details.
+'
+
+  let issue_author = "unvouched"
+  let owner = "mitchellh"
+  let repo_name = "vouch"
+  let default_branch = "main";
+
+  const template_file = path self ../vouch/templates/github-issue-unvouched
+  let got = {
+    author: $issue_author,
+    owner: $owner,
+    repo: $repo_name,
+    default_branch: $default_branch,
+  } | template render $template_file
+
+  assert equal $want $got
+}

--- a/vouch/template.nu
+++ b/vouch/template.nu
@@ -1,0 +1,29 @@
+# Template helper module.
+
+# Template engine based off of Nushell's "format pattern".
+#
+# Only designed to be used in vouch code - not designed to be used externally.
+#
+# To use, pass the record set representing the template arguments into the
+# command, with the path:
+#
+#   { ... } | template render templates/example
+#
+# Example: 
+#
+#   # Render the GitHub PR unvouched template:
+#   const $template_file = path self ./templates/github-pr-unvouched
+#   {
+#     author: $pr_author,
+#     owner: $repo_parts.owner,
+#     repo: $repo_parts.name,
+#     default_branch: $default_branch,
+#   } | template render $template_file
+#
+export def render [
+  path: string, # The path of the template
+]: record -> string {
+  let input = open --raw $path
+  let out = $in | format pattern $input
+  $out
+}

--- a/vouch/templates/github-issue-unvouched
+++ b/vouch/templates/github-issue-unvouched
@@ -1,0 +1,5 @@
+Hi @{author}, thanks for your interest!
+
+This project requires that issue reporters are vouched, and you are not in the list of vouched users. 
+
+This issue will be closed automatically. See https://github.com/{owner}/{repo}/blob/{default_branch}/CONTRIBUTING.md for more details.

--- a/vouch/templates/github-pr-unvouched
+++ b/vouch/templates/github-pr-unvouched
@@ -1,0 +1,5 @@
+Hi @{author}, thanks for your interest in contributing!
+
+This project requires that pull request authors are vouched, and you are not in the list of vouched users. 
+
+This PR will be closed automatically. See https://github.com/{owner}/{repo}/blob/{default_branch}/CONTRIBUTING.md for more details.


### PR DESCRIPTION
This adds the ability to customize the response used for *unvouched* users when closing pull requests or issues.

For both `gh-check-pr` and `gh-check-issue`, the `--template-file` argument allows the ability to supply an optional template for use. This template follows the expansion rules as defined in Nushell's `format pattern`.

The default messages for both of these have been moved to a new `templates` sub-directory and are now templates themselves, serving as an example for both how to template and also the arguments available (although they have also been documented).

`template-file` has also been added as an argument for the respective workflows.

Closes #50. 