### PR TITLE
fetch discussion comment URL

### DIFF
--- a/vouch/github.nu
+++ b/vouch/github.nu
@@ -588,8 +588,7 @@ export def gh-manage-by-discussion [
         | lines
         | first
       )
-      let discussion_url = $"https://github.com/($owner)/($repo_name)/discussions/($discussion_number)"
-      let body = $"Triggered by [discussion comment]\(($discussion_url)\) from @($commenter).\n\n($parsed.action | str capitalize): @($target_user)"
+      let body = $"Triggered by [discussion comment]\(($result.data.node.url)\) from @($commenter).\n\n($parsed.action | str capitalize): @($target_user)"
       open-pr $owner $repo_name $branch $title $body --merge-immediately=$merge_immediately
     } else {
       (commit-and-push $file

--- a/vouch/gql/gh-discussion-comment.gql
+++ b/vouch/gql/gh-discussion-comment.gql
@@ -14,6 +14,7 @@ query discussionComment(
   node(id: $comment_node_id) {
     ... on DiscussionComment {
       body
+      url
       author {
         login
       }


### PR DESCRIPTION
Closes #71

Irrelevant for the current state of the PR (so feel free to ignore this entire PR description), but in my issue I said this:
> I had to deal with this in the past (for Ghostty bot actually lol) so I have a fix ready!

What I had to deal with was getting the node ID (`DC_bO8RxDkUrw4=`) from the comment ID present in URLs by manually constructing it. But since we already have the node ID, we can just request the entire comment URL… so yeah, I wasted like 30 minutes on making an explainer diagram for my original solution before realizing it's much simpler 🥲

I don't want it to go to waste, so I'm including it here for fun. Actually -- would it be useful to allow the URL comment ID to be passed into `gh-manage-by-discussion` rather than the GraphQL node ID?

<img width="70%" src="https://github.com/user-attachments/assets/5e1c12b2-3da5-4ffd-9e69-915e8f377e67" />