### PR TITLE
Add vouch CLI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,3 +59,17 @@ jobs:
         run: nu tests/run.nu --slow
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  setup-vouch:
+    if: >
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.head.repo.full_name != github.repository)
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./action/setup-vouch
+      - run: vouch
+      - run: vouch add --help

--- a/action/setup-vouch/action.yml
+++ b/action/setup-vouch/action.yml
@@ -16,29 +16,15 @@ runs:
       with:
         version: "*"
 
-    # Generate a bash wrapper script and a small Nu entrypoint that
-    # loads the vouch module. Place the wrapper on PATH so subsequent
-    # steps can call `vouch` directly.
+    # Expose the checked-in wrapper on PATH and persist the module
+    # location for subsequent workflow steps that call `vouch`.
     - shell: nu {0}
       run: |
-        let vouch_root = ("${{ github.action_path }}" | path join ".." ".." | path expand)
-        let bin_dir = ($vouch_root | path join ".vouch-bin")
-        mkdir $bin_dir
+        let vouch_lib_dir = (
+          "${{ github.action_path }}"
+          | path join ".." ".." "vouch"
+          | path expand
+        )
 
-        let vouch_mod = ($vouch_root | path join "vouch")
-        [
-          "#!/usr/bin/env bash"
-          "# Nu modules can't be invoked directly as scripts, so we use"
-          "# nu -c with 'use vouch *' to bring subcommands into scope."
-          "#"
-          "# Build a shell-safe argument string from the caller's args."
-          "cmd=''"
-          "for a in \"$@\"; do cmd=\"$cmd $(printf '%q' \"$a\")\"; done"
-          "# With no args, call 'vouch main' for usage info since bare"
-          "# 'vouch' doesn't resolve via 'use vouch *'."
-          $"if [ $# -eq 0 ]; then cmd='vouch main'; fi"
-          $"exec nu --no-config-file -c \"use ($vouch_mod) *; $cmd\""
-        ] | str join "\n" | save -f ($bin_dir | path join "vouch")
-        chmod +x ($bin_dir | path join "vouch")
-
-        $bin_dir | save --append $env.GITHUB_PATH
+        $"VOUCH_LIB_DIR=($vouch_lib_dir)" | save --append $env.GITHUB_ENV
+        "${{ github.action_path }}" | save --append $env.GITHUB_PATH

--- a/action/setup-vouch/vouch
+++ b/action/setup-vouch/vouch
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+vouch_lib_dir="${VOUCH_LIB_DIR:-}"
+
+if [ -z "$vouch_lib_dir" ]; then
+  script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+  vouch_lib_dir="$(cd -- "$script_dir/../.." && pwd)/vouch"
+fi
+
+export VOUCH_LIB_DIR="$vouch_lib_dir"
+
+cmd=""
+for a in "$@"; do
+  cmd="$cmd $(printf '%q' "$a")"
+done
+
+# With no args, call 'vouch main' for usage info since bare
+# 'vouch' doesn't resolve via 'use vouch *'.
+if [ $# -eq 0 ]; then
+  cmd="vouch main"
+fi
+
+exec nu --no-config-file -c "use \"$VOUCH_LIB_DIR\" *; $cmd"


### PR DESCRIPTION
instead of writing a CLI dynamically, how about we ship one with this repo?

this is required for putting vouch on homebrew, xref https://github.com/Homebrew/homebrew-core/pull/269267#discussion_r2852092812

xref #26

WDYT of this approach @mitchellh?

verified it works locally by running `./action/setup-vouch/vouch add --help`. added a test for `setup-vouch` as well but didn't test this yet