### PR TITLE
Add projects using vouch section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,11 @@ $records | denounce-user "badactor" "reason"                 # returns updated t
 $records | remove-user "olduser"                             # returns updated table
 ```
 
+## Projects Using Vouch
+
+- [Ghostty](https://github.com/ghostty-org/ghostty) - Uses vouch to manage contributor trust via GitHub Actions.
+- [GitBaz](https://github.com/HappyHackingSpace/gitbaz) - Uses vouch in the repo and displays vouch status in its Chrome extension's contributor panel.
+
 ## Vouched File Format
 
 The vouch list is stored in a `.td` file. See


### PR DESCRIPTION
## Summary
- Add a "Projects Using Vouch" section to the README listing Ghostty and GitBaz.

<img width="312" height="558" alt="image" src="https://github.com/user-attachments/assets/957b3558-85e9-4170-a1cc-99a9e54a684c" />
<img width="310" height="557" alt="image" src="https://github.com/user-attachments/assets/5594b0cf-e601-4b0d-b3fd-fd4dc884b01f" />
