### PR TITLE
feat: use @example attribute for command examples

### DIFF
--- a/vouch/cli.nu
+++ b/vouch/cli.nu
@@ -7,18 +7,9 @@ use lib.nu [add-user, check-user, denounce-user, remove-user]
 #
 # This adds the user to the vouched list, removing any existing entry
 # (vouched or denounced) for that user first.
-#
-# Examples:
-#
-#   # Preview new file contents (default)
-#   ./vouch.nu add someuser
-#
-#   # Write the file in-place
-#   ./vouch.nu add someuser --write
-#
-#   # Add with platform prefix
-#   ./vouch.nu add github:someuser --write
-#
+@example "Preview new file contents (default)" { ./vouch.nu add someuser }
+@example "Write the file in-place" { ./vouch.nu add someuser --write }
+@example "Add with platform prefix" { ./vouch.nu add github:someuser --write }
 export def add [
   username: string,          # Username to vouch for (supports platform:user format)
   --default-platform: string = "", # Assumed platform for entries without explicit platform
@@ -54,12 +45,8 @@ export def add [
 #   0 - vouched
 #   1 - denounced
 #   2 - unknown
-#
-# Examples:
-#
-#   ./vouch.nu check someuser
-#   ./vouch.nu check github:someuser
-#
+@example "Check a user using the default platform" { ./vouch.nu check someuser }
+@example "Check a user and specify the platform" { ./vouch.nu check github:someuser }
 export def check [
   username: string,          # Username to check (supports platform:user format)
   --default-platform: string = "", # Assumed platform for entries without explicit platform
@@ -98,21 +85,10 @@ export def check [
 #
 # This removes any existing entry for the user and adds them as denounced.
 # An optional reason can be provided which will be added after the username.
-#
-# Examples:
-#
-#   # Preview new file contents (default)
-#   ./vouch.nu denounce badactor
-#
-#   # Denounce with a reason
-#   ./vouch.nu denounce badactor --reason "Submitted AI slop"
-#
-#   # Write the file in-place
-#   ./vouch.nu denounce badactor --write
-#
-#   # Denounce with platform prefix
-#   ./vouch.nu denounce github:badactor --write
-#
+@example "Preview new file contents (default)" { ./vouch.nu denounce badactor }
+@example "Denounce with a reason" { ./vouch.nu denounce badactor --reason "Submitted AI slop" }
+@example "Write the file in-place" { ./vouch.nu denounce badactor --write }
+@example "Denounce with platform prefix" { ./vouch.nu denounce github:badactor --write }
 export def denounce [
   username: string,          # Username to denounce (supports platform:user format)
   --default-platform: string = "", # Assumed platform for entries without explicit platform
@@ -165,18 +141,9 @@ export def main [] {
 #
 # This removes any existing entry (vouched or denounced) for the user.
 # The user will become unknown after this operation.
-#
-# Examples:
-#
-#   # Preview new file contents (default)
-#   ./vouch.nu remove someuser
-#
-#   # Write the file in-place
-#   ./vouch.nu remove someuser --write
-#
-#   # Remove with platform prefix
-#   ./vouch.nu remove github:someuser --write
-#
+@example "Preview new file contents (default)" { ./vouch.nu remove someuser }
+@example "Write the file in-place" { ./vouch.nu remove someuser --write }
+@example "Remove with platform prefix" { ./vouch.nu remove github:someuser --write }
 export def remove [
   username: string,          # Username to remove (supports platform:user format)
   --default-platform: string = "", # Assumed platform for entries without explicit platform

--- a/vouch/codeowners.nu
+++ b/vouch/codeowners.nu
@@ -6,15 +6,14 @@
 # of file patterns they own. Owners are sorted alphabetically.
 #
 # Owners have the leading "@" stripped.
-#
-# Example:
-#   open -r CODEOWNERS | parse-codeowners
-#   ╭───┬────────────┬──────────────────╮
-#   │ # │   owner    │      files       │
-#   ├───┼────────────┼──────────────────┤
-#   │ 0 │ acme/core  │ [/src/]          │
-#   │ 1 │ bob        │ [/src/, /docs/]  │
-#   ╰───┴────────────┴──────────────────╯
+@example "Parse codeowners" { open -r CODEOWNERS | parse-codeowners } --result "
+╭───┬────────────┬──────────────────╮
+│ # │   owner    │      files       │
+├───┼────────────┼──────────────────┤
+│ 0 │ acme/core  │ [/src/]          │
+│ 1 │ bob        │ [/src/, /docs/]  │
+╰───┴────────────┴──────────────────╯
+"
 export def parse-codeowners []: string -> table<owner: string, files: list<string>> {
   $in
     | lines

--- a/vouch/github.nu
+++ b/vouch/github.nu
@@ -41,18 +41,9 @@ const issue_template = path self ./templates/github-issue-unvouched
 # can be used as an example.
 #
 # Outputs status: "skipped" (bot), "vouched", "allowed", or "closed".
-#
-# Examples:
-#
-#   # Check PR author status (dry run)
-#   ./vouch.nu gh-check-pr 123
-#
-#   # Auto-close unvouched PRs
-#   ./vouch.nu gh-check-pr 123 --auto-close --dry-run=false
-#
-#   # Allow unvouched users, only block denounced
-#   ./vouch.nu gh-check-pr 123 --require-vouch=false --auto-close
-#
+@example "Check PR author status (dry run)" { ./vouch.nu gh-check-pr 123 }
+@example "Auto-close unvouched PRs" { ./vouch.nu gh-check-pr 123 --auto-close --dry-run=false }
+@example "Allow unvouched users, only block denounced" { ./vouch.nu gh-check-pr 123 --require-vouch=false --auto-close }
 export def gh-check-pr [
   pr_number: int,              # GitHub PR number
   --repo (-R): string,         # Repository in "owner/repo" format (required)
@@ -183,18 +174,9 @@ export def gh-check-pr [
 # which can be used as an example.
 #
 # Outputs status: "skipped" (bot), "vouched", "allowed", or "closed".
-#
-# Examples:
-#
-#   # Check issue author status (dry run)
-#   ./vouch.nu gh-check-issue 123
-#
-#   # Auto-close unvouched issues
-#   ./vouch.nu gh-check-issue 123 --auto-close --dry-run=false
-#
-#   # Allow unvouched users, only block denounced
-#   ./vouch.nu gh-check-issue 123 --require-vouch=false --auto-close
-#
+@example "Check issue author status (dry run)" { ./vouch.nu gh-check-issue 123 }
+@example "Auto-close unvouched issues" { ./vouch.nu gh-check-issue 123 --auto-close --dry-run=false }
+@example "Allow unvouched users, only block denounced" { ./vouch.nu gh-check-issue 123 --require-vouch=false --auto-close }
 export def gh-check-issue [
   issue_number: int,             # GitHub issue number
   --repo (-R): string,           # Repository in "owner/repo" format (required)
@@ -336,21 +318,10 @@ export def gh-check-issue [
 # customize the trigger words. Multiple keywords can be specified as a list.
 #
 # Outputs a status to stdout: "vouched", "denounced", "unvouched", or "unchanged"
-#
-# Examples:
-#
-#   # Dry run (default) - see what would happen
-#   ./vouch.nu gh-manage-by-issue 123 456789
-#
-#   # Actually perform the action
-#   ./vouch.nu gh-manage-by-issue 123 456789 --dry-run=false
-#
-#   # Custom vouch keywords
-#   ./vouch.nu gh-manage-by-issue 123 456789 --vouch-keyword [lgtm approve]
-#
-#   # Create a pull request instead of pushing directly
-#   ./vouch.nu gh-manage-by-issue 123 456789 --pull-request --dry-run=false
-#
+@example "Dry run (default) - see what would happen" { ./vouch.nu gh-manage-by-issue 123 456789 }
+@example "Actually perform the action" { ./vouch.nu gh-manage-by-issue 123 456789 --dry-run=false }
+@example "Custom vouch keywords" { ./vouch.nu gh-manage-by-issue 123 456789 --vouch-keyword [lgtm approve] }
+@example "Create a pull request instead of pushing directly" { ./vouch.nu gh-manage-by-issue 123 456789 --pull-request --dry-run=false }
 export def gh-manage-by-issue [
   issue_id: int,           # GitHub issue number
   comment_id: int,         # GitHub comment ID
@@ -502,24 +473,11 @@ export def gh-manage-by-issue [
 # customize the trigger words. Multiple keywords can be specified as a list.
 #
 # Outputs a status to stdout: "vouched", "denounced", "unvouched", or "unchanged"
-#
-# Examples:
-#
-#   # Dry run (default) - see what would happen
-#   ./vouch.nu gh-manage-by-discussion 42 DC_kwDOExample
-#
-#   # Dry run with a numerical ID found in URLs
-#   ./vouch.nu gh-manage-by-discussion 42 11579492
-#
-#   # Actually perform the action
-#   ./vouch.nu gh-manage-by-discussion 42 DC_kwDOExample --dry-run=false
-#
-#   # Custom vouch keywords
-#   ./vouch.nu gh-manage-by-discussion 42 DC_kwDOExample --vouch-keyword [lgtm approve]
-#
-#   # Create a pull request instead of pushing directly
-#   ./vouch.nu gh-manage-by-discussion 42 DC_kwDOExample --pull-request --dry-run=false
-#
+@example "Dry run (default) - see what would happen" { ./vouch.nu gh-manage-by-discussion 42 DC_kwDOExample }
+@example "Dry run with a numerical ID found in URLs" { ./vouch.nu gh-manage-by-discussion 42 11579492 }
+@example "Actually perform the action" { ./vouch.nu gh-manage-by-discussion 42 DC_kwDOExample --dry-run=false }
+@example "Custom vouch keywords" { ./vouch.nu gh-manage-by-discussion 42 DC_kwDOExample --vouch-keyword [lgtm approve] }
+@example "Create a pull request instead of pushing directly" { ./vouch.nu gh-manage-by-discussion 42 DC_kwDOExample --pull-request --dry-run=false }
 export def gh-manage-by-discussion [
   discussion_number: int,  # GitHub discussion number
   comment_node_id: oneof<int, string>, # GraphQL node ID or numerical URL ID of the comment (e.g. DC_kwDO... or 11579492)

--- a/vouch/lib.nu
+++ b/vouch/lib.nu
@@ -120,21 +120,18 @@ export def remove-user [
 #   - action: "vouch", "denounce", "unvouch", or null if no match
 #   - user: target username (or null if not specified)
 #   - reason: reason string (or "" if not specified; always "" for unvouch)
-#
-# Examples:
-#
-#   parse-comment "vouch"
-#   # => {action: vouch, user: null, reason: ""}
-#
-#   parse-comment "vouch @alice good work"
-#   # => {action: vouch, user: alice, reason: "good work"}
-#
-#   parse-comment "denounce @badguy spammer"
-#   # => {action: denounce, user: badguy, reason: spammer}
-#
-#   parse-comment "random text"
-#   # => {action: null, user: null, reason: ""}
-#
+@example "Vouch without specifying the user" { parse-comment "vouch" } --result "
+{action: vouch, user: null, reason: \"\"}  
+"
+@example "Vouch a specified user with a reason" { parse-comment "vouch @alice good work" } --result "
+{action: vouch, user: alice, reason: \"good work\"}  
+"
+@example "Denounce a user with a reason" { parse-comment "denounce @badguy spammer" } --result "
+{action: denounce, user: badguy, reason: spammer}  
+"
+@example "No vouching or denouncing" { parse-comment "random text" } --result "
+{action: null, user: null, reason: ""}  
+"
 export def parse-comment [
   body: string,                                     # Comment body to parse
   --vouch-keyword: list<string> = ["vouch"],        # Keywords that trigger vouching


### PR DESCRIPTION
As discussed in #85, this PR moves commented examples for Nu commands to the `@example` attribute. This improves the documentation experience for users and cleans up the code. 

There were a few places where the example comments didn't have a description, which is required by the `@example` attribute. I will comment on those and you can update the wording if you don't think it describes the command well.