### PR TITLE
Fix setup wrapper quoting for multi-word args

### DIFF
--- a/action/setup-vouch/vouch
+++ b/action/setup-vouch/vouch
@@ -10,9 +10,22 @@ fi
 
 export VOUCH_LIB_DIR="$vouch_lib_dir"
 
+nu_lib_dir="${VOUCH_LIB_DIR//\\/\\\\}"
+nu_lib_dir="${nu_lib_dir//\"/\\\"}"
+
+quote_nu_arg() {
+  if [[ "$1" =~ ^[A-Za-z0-9_./:@%+=,-]+$ ]]; then
+    printf '%s' "$1"
+  else
+    local arg="${1//\\/\\\\}"
+    arg="${arg//\"/\\\"}"
+    printf '"%s"' "$arg"
+  fi
+}
+
 cmd=""
 for a in "$@"; do
-  cmd="$cmd $(printf '%q' "$a")"
+  cmd="$cmd $(quote_nu_arg "$a")"
 done
 
 # With no args, call 'vouch main' for usage info since bare
@@ -21,4 +34,4 @@ if [ $# -eq 0 ]; then
   cmd="vouch main"
 fi
 
-exec nu --no-config-file -c "use \"$VOUCH_LIB_DIR\" *; $cmd"
+exec nu --no-config-file -c "use \"$nu_lib_dir\" *; $cmd"


### PR DESCRIPTION
Fixes #94.

The setup-vouch wrapper was using Bash `printf %q` to build a Nushell command string. That escaping is shell-specific, so multi-word values such as custom commit messages or denounce reasons can be split or misparsed before reaching the Nushell command.

This changes the wrapper to quote arguments as Nushell double-quoted literals only when needed, while leaving command names and flags bare. It also escapes the resolved `VOUCH_LIB_DIR` path before embedding it in the `use` statement.

Verification:
- `bash -n action/setup-vouch/vouch`
- local wrapper smoke test with `--reason "AI slop with spaces" --write`, confirming the full reason was written as one value
- no-argument wrapper smoke test still prints usage
- `nu tests/run.nu --fast`
- `git diff --check`